### PR TITLE
Buildsystem: ninja v1.11.1 will not be detected by Pacman

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -61,7 +61,7 @@ runs:
         zip \
         python3-pip
         sudo pip3 install meson
-        sudo pip3 install ninja
+        sudo pip3 install ninja==1.10.2.4
     - id: install_pacman
       shell: bash
       env:


### PR DESCRIPTION
just a workaround until Arch have fixed it on Pacman or Manjaro will do a patch ;)